### PR TITLE
Leave the setting for ignorePlurals to the source index

### DIFF
--- a/connector/src/source_index.rb
+++ b/connector/src/source_index.rb
@@ -123,8 +123,7 @@ class SourceIndex
       SEARCH_PARAMETERS.merge(
         queryType: 'prefixNone',
         typoTolerance: false,
-        removeWordsIfNoResults: 'none',
-        ignorePlurals: false,
+        removeWordsIfNoResults: 'none',        
         facets: facets,
         maxValuesPerFacet: max_facet_values
       )


### PR DESCRIPTION
Hi, 

We noticed when working with the scoped suggestions, that the suggestions didn't really make sense. 

**Expected behaviour**
We would expect the top suggestion for a query scope, to be the most occurring facet value when performing the suggested search on the source index. That was not the case for us. 

**Cause**
Some digging revealed that this was due to the `ignorePlurals` setting that is being set to `false` when querying for the facet values. 

**Proposed fix**
This PR will not set the `ignorePlurals` search query parameter anymore, and leave the setting to the settings of the source index. 

From our perspective that makes the most sense, and it results in the scoping suggestion matching the top facet value when actually searching for the suggested term in the index. 

